### PR TITLE
Add login for mobile client

### DIFF
--- a/IdentityServerPoseify/Config.cs
+++ b/IdentityServerPoseify/Config.cs
@@ -26,7 +26,6 @@ public static class Config
             new Client
             {
                 ClientId = "PoseifyBff",
-                ClientSecrets = { new Secret("secret".Sha256()) },
 
                 AllowedGrantTypes = GrantTypes.Code,
                     
@@ -49,7 +48,6 @@ public static class Config
             new Client
             {
                 ClientId = "PoseifyNative",
-                ClientSecrets = { new Secret("hehe".Sha256()) },
                 
                 AllowedGrantTypes = GrantTypes.Code,
                 AllowOfflineAccess = true,

--- a/IdentityServerPoseify/Config.cs
+++ b/IdentityServerPoseify/Config.cs
@@ -31,13 +31,38 @@ public static class Config
                 AllowedGrantTypes = GrantTypes.Code,
                     
                 // where to redirect to after login
-                RedirectUris = { "https://localhost:44462/signin-oidc" },
+                RedirectUris = { "https://localhost:44462/signin-oidc", "https://poseify.ngrok.app/signin-oidc" },
 
                 // where to redirect to after logout
-                PostLogoutRedirectUris = { "https://localhost:44462/signout-callback-oidc" },
+                PostLogoutRedirectUris = { "https://localhost:44462/signout-callback-oidc", "https://poseify.ngrok.app/signout-callback-oidc" },
 
                 //AllowOfflineAccess = true,
                 AlwaysIncludeUserClaimsInIdToken = true,
+
+                AllowedScopes = new List<string>
+                {
+                    IdentityServerConstants.StandardScopes.OpenId,
+                    IdentityServerConstants.StandardScopes.Profile,
+                    "poseifyApiScope"
+                }
+            },
+            new Client
+            {
+                ClientId = "PoseifyNative",
+                ClientSecrets = { new Secret("hehe".Sha256()) },
+                
+                AllowedGrantTypes = GrantTypes.Code,
+                AllowOfflineAccess = true,
+                RequirePkce = true,  // Enforce PKCE
+                RequireClientSecret = false,
+                RefreshTokenUsage = TokenUsage.ReUse,
+                RequireConsent = false,
+                AlwaysIncludeUserClaimsInIdToken = true,    
+
+                // where to redirect to after login
+                RedirectUris = { "exp://192.168.0.17:8081" },
+                // where to redirect to after logout
+                PostLogoutRedirectUris = { "exp://192.168.0.17:8081" },
 
                 AllowedScopes = new List<string>
                 {

--- a/IdentityServerPoseify/Program.cs
+++ b/IdentityServerPoseify/Program.cs
@@ -13,6 +13,7 @@ try
 
     builder.Host.UseSerilog((ctx, lc) => lc
         .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}")
+        .WriteTo.Debug()
         .Enrich.FromLogContext()
         .ReadFrom.Configuration(ctx.Configuration));
 


### PR DESCRIPTION
Adds the setup for a mobile client. With this a mobile app can access the bff via access tokens that a user can get and store locally.